### PR TITLE
Fix tag

### DIFF
--- a/notebooks/11-html-tags-nb.md
+++ b/notebooks/11-html-tags-nb.md
@@ -75,7 +75,6 @@ ol_fragment = `<div><p> the same with a &amp;lt;ol&amp;gt; tag instead</p>
 <li> the first bullet </li>
 <li> the second bullet </li>
 </ol>
-</p>
 </div>
 `;
 tools.sample_from_strings({html: ol_fragment})

--- a/notebooks/11-html-tags-nb.md
+++ b/notebooks/11-html-tags-nb.md
@@ -54,7 +54,7 @@ tools.sample_from_strings({html: text_fragment})
 ```{code-cell}
 :tags: [hide-input]
 
-ul_fragment = `<p> a typical bullet list with a &amp;lt;ul&amp;gt; tag
+ul_fragment = `<p> a typical bullet list with a &amp;lt;ul&amp;gt; tag</p>
 <br> <code>ul</code> stands for "unordered list"
 <br> <code>li</code> stands for "list item"
 <ul>
@@ -69,13 +69,14 @@ tools.sample_from_strings({html: ul_fragment})
 ```{code-cell}
 :tags: [hide-input]
 
-ol_fragment = `<p> the same with a &amp;lt;ol&amp;gt; tag instead
+ol_fragment = `<div><p> the same with a &amp;lt;ol&amp;gt; tag instead</p>
 <br> <code>ol</code> stands for "ordered list"
 <ol>
 <li> the first bullet </li>
 <li> the second bullet </li>
 </ol>
 </p>
+</div>
 `;
 tools.sample_from_strings({html: ol_fragment})
 ```

--- a/notebooks/11-html-tags-nb.md
+++ b/notebooks/11-html-tags-nb.md
@@ -54,14 +54,14 @@ tools.sample_from_strings({html: text_fragment})
 ```{code-cell}
 :tags: [hide-input]
 
-ul_fragment = `<p> a typical bullet list with a &amp;lt;ul&amp;gt; tag</p>
+ul_fragment = `<div><p> a typical bullet list with a &amp;lt;ul&amp;gt; tag</p>
 <br> <code>ul</code> stands for "unordered list"
 <br> <code>li</code> stands for "list item"
 <ul>
 <li> the first bullet </li>
 <li> the second bullet </li>
 </ul>
-</p>
+</div>
 `;
 tools.sample_from_strings({html: ul_fragment})
 ```


### PR DESCRIPTION
Eviter de mettre un <ol> dans un <p>. TLDR -> pas de composant 'flow' dans un <p>.

https://stackoverflow.com/a/5681796/1839692 pour le détail.

Ceci est utile de le changer pour plusieurs raisons :
* sur le site web le tag </p> apparait en rouge pour signifier une erreur
* si tu mets cela dans un framework il gueule